### PR TITLE
OUJS fixes

### DIFF
--- a/Manga_OnlineViewer.meta.js
+++ b/Manga_OnlineViewer.meta.js
@@ -6,6 +6,7 @@
 // @namespace https://github.com/TagoDR
 // @description Shows all pages at once in online view for these sites: Batoto, ComiCastle, Dynasty-Scans, EatManga, Easy Going Scans, FoOlSlide, KissManga, MangaDoom, MangaFox, MangaGo, MangaHere, MangaInn, MangaLyght, MangaPark, MangaReader,MangaPanda, MangaStream, MangaTown, NineManga, ReadManga.Today, SenManga(Raw), TenManga, TheSpectrum, MangaDeep, Funmanga, UnionMangas, MangaHost, Hoc Vien Truyen Tranh
 // @version 13.22.0
+// @license MIT
 // @date 2017-12-06
 // @grant GM_getValue
 // @grant GM_setValue

--- a/Manga_OnlineViewer.user.js
+++ b/Manga_OnlineViewer.user.js
@@ -6,6 +6,7 @@
 // @namespace https://github.com/TagoDR
 // @description Shows all pages at once in online view for these sites: Batoto, ComiCastle, Dynasty-Scans, EatManga, Easy Going Scans, FoOlSlide, KissManga, MangaDoom, MangaFox, MangaGo, MangaHere, MangaInn, MangaLyght, MangaPark, MangaReader,MangaPanda, MangaStream, MangaTown, NineManga, ReadManga.Today, SenManga(Raw), TenManga, TheSpectrum, MangaDeep, Funmanga, UnionMangas, MangaHost, Hoc Vien Truyen Tranh
 // @version 13.22.0
+// @license MIT
 // @date 2017-12-06
 // @grant GM_getValue
 // @grant GM_setValue


### PR DESCRIPTION
In accordance with your licensing in `package.json` at [/TagoDR/MangaOnlineViewer/blob/`39ff775`/package.json#L10](https://github.com/TagoDR/MangaOnlineViewer/blob/39ff7752b2fb1420860dfc9f362cf08e2a0e13a4/package.json#L10) I've added the required `@license` key to this script and it's meta.

I see you have the same script on OUJS with Portuguese translation but I don't see it here so this PR won't include that.

I realize you stated you are on vacation in another issue but if you get a moment to merge this, assuming your webhook is enabled, it should auto-update OUJS.

Without these changes you will be unable to post new versions to OUJS and the github webhook push will be rejected... plus you are already incurring a new issue on OUJS regarding something that appears to be fixed here on GH. Not everyone has script updating in their .user.js engines and it may not happen right away so it's best to keep your repo here on GH and OUJS in sync.

Thanks for the look,
OUJS Staff