### PR TITLE
use original filename if possible, more accurate extension detection

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -6,22 +6,37 @@ const cache = {
   Data: {},
 };
 
+const getExtension = (mimeType) => ((((/image\/(?<ext>jpe?g|png|webp)/.exec(mimeType) || {}).groups || {}).ext || '') || 'png');
+const getFilename = (name, index, total, ext) => `${name}${(index + 1).toString().padStart(Math.floor(Math.log10(total)) + 1, '0')}.${ext.replace('jpeg', 'jpg')}`;
+
 // Generate Zip File for download
 function generateZip() {
   // Source: http://stackoverflow.com/questions/8778863/downloading-an-image-using-xmlhttprequest-in-a-userscript/8781262#8781262
   if (cache.downloadFiles === 0) {
-    $('.MangaPage img').get().forEach((value, index) => {
+    const filenameRegex = /^(?<name>.*?)(?<index>\d+)\.(?<ext>\w+)$/;
+    const images = $('.MangaPage img');
+    const filenames = (() => {
+      const result = [];
+      for (let i = 0; i < images.length; i += 1) {
+        const img = $(images[i]);
+        const filename = img.attr('src').split(/[?#]/)[0].split('/').pop();
+        const match = filenameRegex.exec(filename);
+        if (!match) break;
+        const { name, index, ext } = match.groups;
+        const fixedFilename = getFilename(name, index, images.length, ext);
+        if (result.length > 0 && fixedFilename <= result[result.length - 1]) break;
+        result.push(fixedFilename);
+      }
+      if (result.length < images.length) return [];
+      return result;
+    })();
+    images.get().forEach((value, index) => {
       const img = $(value);
       const src = img.attr('src');
-      const ext = src.substring(0, 20).match(/jpg|png|webp/ig) || ['png'];
-      const filename = `Page ${String(`000${index + 1}`).slice(-3)}.${ext[0]}`;
-      if (src.indexOf('base64') > -1) {
-        let base64 = src.replace('data:image/png;base64,', '');
-        const i = base64.indexOf(',');
-        if (i !== -1) {
-          base64 = base64.substring(i + 1, base64.length);
-        }
-        cache.zip.file(filename, base64, {
+      const base64 = /^data:(?<mimeType>image\/\w+);base64,+(?<data>.+)/.exec(src);
+      if (base64) {
+        const filename = getFilename('Page ', index, images.length, getExtension(base64.groups.mimeType));
+        cache.zip.file(filename, base64.groups.data, {
           base64: true,
           createFolders: true,
         });
@@ -35,6 +50,7 @@ function generateZip() {
             overrideMimeType: 'text/plain; charset=x-user-defined',
             responseType: 'blob',
             onload(request) {
+              const filename = filenames[index] || getFilename('Page ', index, images.length, getExtension(request.response.type));
               cache.zip.file(filename, request.response, {
                 base64: true,
                 createFolders: true,


### PR DESCRIPTION
Hello,

This PR is solve 2 purposes:
1. Try to keep the original filenames with minimal adjustment. It might be helpful in some cases (for example, downloading from a website and you want to verify using torrent). The original filename will be used only if:
    - We can extract file names from all images.
    - Filenames must be in the same order as the images after index padding.
2. Leverage the mime type from the base64 image and the header of the downloaded images to get more accurate file extension.

I made this change for my personal use. If it doesn't align with the project, feel free to close it.