### PR TITLE
Fixed: selecting the wrong images on latest chatper for weebcentral

### DIFF
--- a/src/main/weebcentral.ts
+++ b/src/main/weebcentral.ts
@@ -5,9 +5,9 @@ export default {
   homepage: 'https://weebcentral.com/',
   language: ['English'],
   category: 'manga',
-  waitEle: 'main section img',
+  waitEle: 'main section .maw-w-full',
   async run() {
-    const src = [...document.querySelectorAll('main section img')].map((elem) =>
+    const src = [...document.querySelectorAll('main section .maw-w-full')].map((elem) =>
       elem.getAttribute('src'),
     );
     const chaptersList = await fetch(


### PR DESCRIPTION
Currently when on the latest chapter it only grabs affiliate images (hit the next button on latest chapter, without script active).
This fixes that