### PR TITLE
Bugfix: ensure all images with image-<number> IDs are loaded for Mgeko site

### DIFF
--- a/src/main/mgeko.ts
+++ b/src/main/mgeko.ts
@@ -8,7 +8,7 @@ const mgeko: ISite = {
   language: [Language.ENGLISH],
   category: Category.MANGA,
   run(): IManga {
-    const images = [...document.querySelectorAll('#chapter-reader img')];
+    const images = [...document.querySelectorAll('img[id^="image-"]')];
     return {
       title: document.querySelector('.titles')?.textContent?.trim(),
       series: document.querySelector('.titles a')?.getAttribute('href'),


### PR DESCRIPTION
Fixes #568 where not all images were loading (only 4 were shown). Some images were moved outside of `#chapter-reader`, but since all relevant images use the `image-<number>` ID pattern, selecting by `id^="image-"` ensures every image is included without removing anything.