### PR TITLE
exclude disabled prev/next links from navigation selection for Mgeko

### DIFF
--- a/src/main/mgeko.ts
+++ b/src/main/mgeko.ts
@@ -13,8 +13,8 @@ const mgeko: ISite = {
       title: document.querySelector('.titles')?.textContent?.trim(),
       series: document.querySelector('.titles a')?.getAttribute('href'),
       pages: images.length,
-      prev: document.querySelector('.chnav.prev')?.getAttribute('href'),
-      next: document.querySelector('.chnav.next')?.getAttribute('href'),
+      prev: document.querySelector('.chnav.prev:not(.isDisabled)')?.getAttribute('href'),
+      next: document.querySelector('.chnav.next:not(.isDisabled)')?.getAttribute('href'),
       listImages: images.map(img => img.getAttribute('src') ?? ''),
     };
   },


### PR DESCRIPTION
Updated navigation query selectors to ignore elements with the `isDisabled` class. This ensures that `prev` and `next` links are only retrieved when navigation buttons are active.

**Details:**

* Replaced `.chnav.prev` and `.chnav.next` selectors with `.chnav.prev:not(.isDisabled)` and `.chnav.next:not(.isDisabled)`
* Prevents fetching `href` attributes from disabled navigation elements