### PR TITLE
Potential fix for code scanning alert no. 129: Incomplete regular expression for hostnames

### DIFF
--- a/src/main/kagane.ts
+++ b/src/main/kagane.ts
@@ -60,7 +60,7 @@ async function collectAllSources(num: number): Promise<string[]> {
 const kagane: ISite = {
   name: 'Kagane',
   homepage: 'https://kagane.org/',
-  url: /https:\/\/(www.)?kagane.org\/series\/.+\/reader\/.+/,
+  url: /https:\/\/(www\.)?kagane\.org\/series\/.+\/reader\/.+/,
   language: Language.ENGLISH,
   category: Category.MANGA,
   waitEle: '.reader-page img',


### PR DESCRIPTION
Potential fix for [https://github.com/TagoDR/MangaOnlineViewer/security/code-scanning/129](https://github.com/TagoDR/MangaOnlineViewer/security/code-scanning/129)

To fix this issue, we should escape the period in `(www.)?` so that it matches a literal dot, not any character. The correct group is `(www\.)?`. Thus, in the file `src/main/kagane.ts`, update the regular expression on line 63 from:

```ts
url: /https:\/\/(www.)?kagane.org\/series\/.+\/reader\/.+/,
```

to

```ts
url: /https:\/\/(www\.)?kagane\.org\/series\/.+\/reader\/.+/,
```

We should also escape the dot in `kagane.org` for completeness and best practices (`kagane\.org`). This makes the regex strictly match URLs pointing to `kagane.org` and its optional `www.` subdomain, ensuring tight host verification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
